### PR TITLE
add naive direct implementation of the equation

### DIFF
--- a/source/JohTConvolution.h
+++ b/source/JohTConvolution.h
@@ -290,4 +290,29 @@ namespace joht_convolution
         }
     }
 
+    /**
+     * @brief Convolution implementation that is directly derived from the equation without any optimization.
+     * 
+     * @tparam ValueType 
+     * @param input pointer to input values
+     * @param kernel pointer to kernel values (e.g. filter coefficients)
+     * @param output pointer to output values
+     * @author JohT
+     */
+    template<typename ValueType>
+    void directlyDerivedFromEquation(const ValueType *const input, const int inputLength, const ValueType *const kernel, const int kernelLength, ValueType *const output)
+    {
+        auto const outSize = inputLength + kernelLength - 1;
+        for (auto outIndex = 0; outIndex < outSize; ++outIndex)
+        {
+            for (auto inputIndex = 0; inputIndex < inputLength; ++inputIndex)
+            {
+                auto const kernelIndex = outIndex - inputIndex;
+                if ((kernelIndex >= 0) && (kernelIndex < kernelLength)) {
+                    output[outIndex] += (input[inputIndex] * kernel[kernelIndex]);
+                }
+            }
+        }
+    }
+
 }// namespace joht_convolution

--- a/test/ConvolutionAlgorithmBenchmarkTest.cpp
+++ b/test/ConvolutionAlgorithmBenchmarkTest.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
 
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::kernelPerInputValueTransposed(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
@@ -53,7 +53,7 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
     BENCHMARK_ADVANCED("(JohT) inputPerKernelValue Transposed" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::inputPerKernelValueTransposed(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
@@ -62,7 +62,7 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
     BENCHMARK_ADVANCED("(JohT) inputPerKernelValue Transposed InnerLoopUnrolled" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::inputPerKernelValueTransposedInnerLoopUnrolled(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
@@ -71,7 +71,7 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
     BENCHMARK_ADVANCED("(JohT) inputPerKernelValue Transposed OuterLoopUnrolled" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::inputPerKernelValueTransposedOuterLoopUnrolled(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
@@ -80,7 +80,7 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
     BENCHMARK_ADVANCED("(JohT) inputPerKernelValue Transposed Inner&OuterLoopUnrolled" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::inputPerKernelValueTransposedInnerAndOuterLoopUnrolled(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
@@ -89,7 +89,7 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
     BENCHMARK_ADVANCED("(JohT) inputPerKernelValue Transposed LoopFission" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::inputPerKernelValueTransposedLoopFission(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
@@ -98,7 +98,7 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
     BENCHMARK_ADVANCED("(JohT) inputPerKernelValue Transposed LoopFissionIndexArithmetic" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::inputPerKernelValueTransposedLoopFissionIndexArithmetic(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
@@ -107,11 +107,25 @@ TEST_CASE("Convolution Implementation Benchmarks", "[.][performance]") //[.] mea
     BENCHMARK_ADVANCED("(JohT) kernelPerInputValue Transposed LoopFission" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)
     {
-        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData, &output]
+        meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
                       {
                           joht_convolution::kernelPerInputValueTransposedLoopFission(inputData, inputLength, kernelData, kernelLength, outputData);
                           return outputData; });
     };
+
+    // The naive implementation, that is directly derived from the equation without any optimization attempts
+    // is about 1000 times slower than "matlab_like::convolution_full" below and more than 5000 times slower than 
+    // the fastest implementations here. 
+    // It is commented out so it doesn't slow down benchmark runs and doesn't break the bar chart scale.
+    //
+    // BENCHMARK_ADVANCED("(JohT) directly derived from equation" + parametrizedBenchmarkDescription)
+    // (Catch::Benchmark::Chronometer meter)
+    // {
+    //     meter.measure([&inputData, &inputLength, &kernelData, &kernelLength, &outputData]
+    //                   {
+    //                       joht_convolution::directlyDerivedFromEquation(inputData, inputLength, kernelData, kernelLength, outputData);
+    //                       return outputData; });
+    // };
 
     BENCHMARK_ADVANCED("(matlab-like) conv 'full' shape" + parametrizedBenchmarkDescription)
     (Catch::Benchmark::Chronometer meter)

--- a/test/JohtConvolutionTest.cpp
+++ b/test/JohtConvolutionTest.cpp
@@ -60,6 +60,11 @@ SCENARIO("JohT Convolution Implementations")
                 joht_convolution::inputPerKernelValueTransposedLoopFissionIndexArithmetic(input.data(), inputLength, kernel.data(),kernelLength, output.data());
                 REQUIRE_THAT(output, Catch::Matchers::Approx(reference));
             }
+            THEN("Algorithm 'directlyDerivedFromEquation' outputs the same result as the reference implementation")
+            {
+                joht_convolution::directlyDerivedFromEquation(input.data(), inputLength, kernel.data(),kernelLength, output.data());
+                REQUIRE_THAT(output, Catch::Matchers::Approx(reference));
+            }
         }
     }
 }


### PR DESCRIPTION
### Changes:
- [add naive direct implementation of the equation](https://github.com/JohT/convolution-benchmarks/pull/27/commits/f735d85069a45bcbec6f6838dcc1f6e0ceed4d55), that is about 1000 times slower than `matlab_like::convolution_full`. The benchmark test for this implementation needs to be activated manually (commented out). Otherwise it would slow down benchmark runs and breaks the scale of the bar chart. Nevertheless it is interesting to see what happens when optimization isn't addressed.