### PR TITLE
Add direct implementation of the equation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ This repository takes different C++ implementations of the [convolution](https:/
 
 - Insights on how a classical convolution algorithm can be implemented and optimized: [BenchmarkCharts.md](./chart/BenchmarkCharts.md)
 - A simple (6 lines of code), easy to read (no intrinsics), yet fast convolution implementation: [inputPerKernelValueTransposed](./source/JohTConvolution.h)
-- Fully automated (CLI) visualization of [Catch2](https://github.com/catchorg/Catch2) benchmark results using  [vega-lite](https://vega.github.io/vega-lite) charts: [chart/README.md](./chart/README.md)
+- Fully automated (CLI) visualization of [Catch2](https://github.com/catchorg/Catch2) benchmark results using [vega-lite](https://vega.github.io/vega-lite) charts: [chart/README.md](./chart/README.md)
 - [GitHub Actions](https://docs.github.com/en/actions) workflow for fully automated benchmarks on Linux, MacOS and Windows: [continuous-integration.yml](.github/workflows/continuous-integration.yml)
-- [Renovate](https://github.com/renovatebot/renovate) configuration to update [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) managed C++ dependencies: [renovate.json](./renovate.json)   
-Blog: [Keep your C++ dependencies up-to-date with Renovate & CPM](https://joht.github.io/johtizen/automation/2022/08/03/keep-your-cpp-dependencies-up-to-date.html)
+- [Renovate](https://github.com/renovatebot/renovate) configuration to update [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) managed C++ dependencies: [renovate.json](./renovate.json)
+
+## 📖 Related Blog Articles
+
+- [A different approach to Convolution](https://joht.github.io/johtizen/algorithm/2022/10/22/a-different-approach-to-convolution.html)
+- [Visualize Catch2 benchmarks with Vega-Lite](https://joht.github.io/johtizen/data/2022/09/05/visualize-catch2-benchmarks-with-vega-lite.html)
+- [Keep your C++ dependencies up-to-date with Renovate & CPM](https://joht.github.io/johtizen/automation/2022/08/03/keep-your-cpp-dependencies-up-to-date.html)
 
 ## 📈 Results
 
@@ -77,7 +82,6 @@ These compile options are used with MSVC as described in [Auto-Vectorizer Report
 [Quick C++ Benchmark](https://quick-bench.com/) is another great tool that compares the performance of two code blocks with each other.
 
 Copy & Paste the following code snipped into [Quick C++ Benchmark](https://quick-bench.com/). It shows the difference between the kernel and the input values as outer loop with a "direct form transposed" convolution implementation.
-
 
 <details>
   <summary>Code Snipped to compare the iteration over the kernel values in the inner vs. the outer loop</summary>
@@ -169,13 +173,14 @@ static void kernelOuter(benchmark::State& state) {
 // Register the function as a benchmark
 BENCHMARK(kernelOuter);
 ```
+
 </details>
 
 ## 📜 History
 
-This repository was initially intended to explore Single Instruction Multiple Data ([SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data)) in C++. Since convolution is such an essential part of filtering in digital signal processing and a central part of convolutional neuronal networks ([CNN](https://en.wikipedia.org/wiki/Convolutional_neural_network)), it seemed obvious to try that first. 
+This repository was initially intended to explore Single Instruction Multiple Data ([SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data)) in C++. Since convolution is such an essential part of filtering in digital signal processing and a central part of convolutional neuronal networks ([CNN](https://en.wikipedia.org/wiki/Convolutional_neural_network)), it seemed obvious to try that first.
 
-A [complex](https://en.wikipedia.org/wiki/Cynefin_framework#Complex) topic like this benefits from a "experiment - evaluate" approach to get started. [Catch2](https://github.com/catchorg/Catch2) is used to assure, that the implementations are correct. It is also used to benchmark their performance. [Compiler Options for vectorization reports](#Compiler-Options-for-vectorization-reports) get insights into what the compiler does. [Online-Tools](#Online-Tools) are used to exploratory experiment with implementations. Finally, to get a visual response, [vega-lite](https://vega.github.io/vega-lite) is used to create bar charts of the benchmark results.
+A [complex](https://en.wikipedia.org/wiki/Cynefin_framework#Complex) topic like this benefits from a "experiment - evaluate" approach to get started. [Catch2](https://github.com/catchorg/Catch2) is used to assure, that the implementations are correct. It is also used to benchmark their performance. [Compiler Options for vectorization reports](#⚙️-compiler-options-for-vectorization-reports) get insights into what the compiler does. [Online-Tools](#🔭-online-tools) are used to exploratory experiment with implementations. Finally, to get a visual response, [vega-lite](https://vega.github.io/vega-lite) is used to create bar charts of the benchmark results.
 
 ## 🔎 References
 

--- a/source/JohTConvolution.h
+++ b/source/JohTConvolution.h
@@ -315,4 +315,30 @@ namespace joht_convolution
         }
     }
 
+    /**
+     * @brief Convolution implementation that is directly derived from the equation 
+     with the branch statement in the outer loop instead of the inner one.
+     * 
+     * @tparam ValueType 
+     * @param input pointer to input values
+     * @param kernel pointer to kernel values (e.g. filter coefficients)
+     * @param output pointer to output values
+     * @author JohT
+     */
+    template<typename ValueType>
+    void directlyDerivedFromEquationWithIfInOuterLoop(const ValueType *const input, const int inputLength, const ValueType *const kernel, const int kernelLength, ValueType *const output)
+    {
+        const auto outSize = inputLength + kernelLength - 1;
+        for (auto outIndex = 0; outIndex < outSize; ++outIndex)
+        {
+            const auto outIndexPlusOne = outIndex + 1;
+            const auto inputMin = (outIndexPlusOne >= kernelLength)? outIndexPlusOne - (kernelLength) : 0;
+            const auto inputMax = (outIndexPlusOne < inputLength)? outIndexPlusOne: inputLength;
+            for (auto inputIndex = inputMin; inputIndex < inputMax; ++inputIndex)
+            {
+                const auto kernelIndex = outIndex - inputIndex;
+                output[outIndex] += (input[inputIndex] * kernel[kernelIndex]);
+            }
+        }
+    }
 }// namespace joht_convolution

--- a/test/JohtConvolutionTest.cpp
+++ b/test/JohtConvolutionTest.cpp
@@ -65,6 +65,11 @@ SCENARIO("JohT Convolution Implementations")
                 joht_convolution::directlyDerivedFromEquation(input.data(), inputLength, kernel.data(),kernelLength, output.data());
                 REQUIRE_THAT(output, Catch::Matchers::Approx(reference));
             }
+            THEN("Algorithm 'directlyDerivedFromEquationWithIfInOuterLoop' outputs the same result as the reference implementation")
+            {
+                joht_convolution::directlyDerivedFromEquationWithIfInOuterLoop(input.data(), inputLength, kernel.data(),kernelLength, output.data());
+                REQUIRE_THAT(output, Catch::Matchers::Approx(reference));
+            }
         }
     }
 }


### PR DESCRIPTION
### Changes
- [Add direct implementation of the equation](https://github.com/JohT/convolution-benchmarks/pull/32/commits/0391508b9fd51794acdd0f02220e29fdca077dc0)
Only meant as reference. Too slow for benchmark. Would exceed the scale.
- [Add related blog articles](https://github.com/JohT/convolution-benchmarks/pull/32/commits/ebbc1d0876ae8d1d290126a7379fc768f1cd5dee) to [README.md](https://github.com/JohT/convolution-benchmarks/blob/main/README.md)