### PR TITLE
Add Apple silicon runner for ARM charts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,6 +92,11 @@ jobs:
           enforce-sse2: FALSE
           enforce-avx: FALSE
           enforce-avx2: FALSE
+        - os: macos-14
+          artifact: MacOS M1
+          enforce-sse2: FALSE
+          enforce-avx: FALSE
+          enforce-avx2: FALSE       
 
     steps:
     


### PR DESCRIPTION
### 🚀 Features

- [Add Apple silicon runner for ARM charts](https://github.com/JohT/convolution-benchmarks/pull/71/commits/dfa2aca27bed7484339a9be0648c344e462193d8) for fully automated charts for Apple Mx ARM CPUs as announced in [Introducing the new M1 macOS runner available to open source](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)